### PR TITLE
Update for compatibility with codox 0.9.0+

### DIFF
--- a/src/leiningen/dash.clj
+++ b/src/leiningen/dash.clj
@@ -10,7 +10,7 @@
   [project & args]
   (info "Generating documentation with Codox ...")
   (codox/codox project)
-  (let [doc-base-dir (io/file (get-in project [:codox :output-dir] "target/doc"))]
+  (let [doc-base-dir (io/file (get-in project [:codox :output-path] "target/doc"))]
     (info "Generating docset ...")
     (-> (g/create-docset-structure project)
         (g/copy-docs doc-base-dir)


### PR DESCRIPTION
The `:output-dir` option has been renamed `:output-path` in Codox [version 0.9.0](https://github.com/weavejester/codox/blob/master/HISTORY.md#090-2015-10-19) and later. This change seems to be what is needed by #2 (with it in place, I am able to build my doc set).
